### PR TITLE
Enhancement - Git Commit SHA

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -5,4 +5,5 @@ return [
     'server' => [
         'base_url' => env('COREMETRICS_BASE_URL'),
     ],
+    'allow-git' => env('COREMETRICS_ALLOW_GIT'),
 ];

--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -24,6 +24,7 @@ class Collector
     const COMPR_ROUTE_URI = 'riu';
     const COMPR_ROUTE_ACTION = 'ria';
     const COMPR_ROUTE_METHOD = 'rim';
+    const COMPR_GIT_COMMIT_SHA = 'gcs';
 
     /** @var CollectorConnectionManager */
     private $connectionManager;
@@ -45,6 +46,9 @@ class Collector
 
     /** @var array */
     private $peakMemoryUsage;
+
+    /** @var string|null */
+    private $gitCommitSha = null;
 
     public function __construct(CollectorConnectionManager $connectionManager)
     {
@@ -73,6 +77,14 @@ class Collector
     public function setPeakMemoryUsage(array $peakMemoryUsage)
     {
         $this->peakMemoryUsage = $peakMemoryUsage;
+    }
+
+    /**
+     * @param string $gitCommitSha
+     */
+    public function setGitCommitSha(string $gitCommitSha)
+    {
+        $this->gitCommitSha = $gitCommitSha;
     }
 
     /**
@@ -112,6 +124,7 @@ class Collector
             self::COMPR_MEMORY_USAGE => $this->peakMemoryUsage['usage'],
             self::COMPR_MEMORY_USAGE_REAL => $this->peakMemoryUsage['real_usage'],
             self::COMPR_PROCESS_EVENT_BUFFER => $this->buffer,
+            self::COMPR_GIT_COMMIT_SHA => $this->gitCommitSha,
         ];
 
         $json = json_encode($data);

--- a/src/EventBinder.php
+++ b/src/EventBinder.php
@@ -312,6 +312,11 @@ class EventBinder
                     'real_usage' => memory_get_peak_usage(true),
                 ]);
 
+                if(config('coremetrics.allow-git')) {
+                    $gitCommitSha = exec('git rev-parse --short HEAD');
+                    $collector->setGitCommitSha($gitCommitSha);
+                }
+
                 $collector->flushBuffer();
 
                 $this->app['coremetrics.connectionManager']->close();


### PR DESCRIPTION
This PR allows us to (optionally) capture a git commit SHA and post it to the server. This can be enabled or disabled with the `COREMETRICS_ALLOW_GIT` config option.