### PR TITLE
Bugfix - Debug Messages

### DIFF
--- a/src/Loggers/LaravelLogger.php
+++ b/src/Loggers/LaravelLogger.php
@@ -131,7 +131,9 @@ class LaravelLogger implements LoggerInterface
      */
     public function debug($message, array $context = [])
     {
-        $this->log(LogLevel::DEBUG, $message, $context);
+        if (config('app.debug')) {
+            $this->log(LogLevel::DEBUG, $message, $context);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Previously, our `debug()` logger method was not respecting the `APP_DEBUG` env var. This made requests take 6-8x longer as we were writing to disk on every request, even in production.