### PR TITLE
Use react/http as HTTP client in Agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "illuminate/support": "~5.0 || ~6.0 || ~7.0 || ~8.0",
         "clue/socket-raw": "^1.4",
         "react/event-loop": "^1.1",
-        "react/socket": "^1.2"
+        "react/socket": "^1.2",
+        "react/http": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
While cURL does it's job just file, its usage in the Agent will block the event loop for the duration of the push. That means it might miss metrics. Missing a bit isn't that much of an issue, but blocking the event loop every X seconds for the duration of that HTTP call, defeats part of the purpose of putting an agent between the application and the metrics service.